### PR TITLE
Keypairs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+dryoc = "0.4.2"
+serde = { version = "1.0.147", features = ["derive"] }
+serde_cbor = "0.10"

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,27 @@
+use std::fmt;
+
+#[derive(Debug)]
+pub enum SelfError {
+    KeyPairDecodeInvalidData,
+    KeyPairSignFailure,
+    KeyPairSignMissingSingingKey,
+    KeyPairSignWrongKeypairType,
+}
+
+impl std::error::Error for SelfError {}
+
+impl fmt::Display for SelfError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            SelfError::KeyPairDecodeInvalidData => write!(f, "Could not decode keypair"),
+            SelfError::KeyPairSignFailure => write!(f, "Signing failed"),
+            SelfError::KeyPairSignWrongKeypairType => {
+                write!(f, "Keypair cannot be used to sign messages")
+            }
+            SelfError::KeyPairSignMissingSingingKey => write!(
+                f,
+                "Keypair cannot be used to sign as its missing it's secret key component"
+            ),
+        }
+    }
+}

--- a/src/keypair.rs
+++ b/src/keypair.rs
@@ -1,0 +1,173 @@
+use dryoc::sign::{Message, PublicKey, SecretKey, Signature, SignedMessage, SigningKeyPair};
+use serde::{Deserialize, Serialize};
+
+use crate::error::SelfError;
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct KeyPair {
+    keypair_type: KeyPairType,
+    public_key: Vec<u8>,
+    secret_key: Vec<u8>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
+pub enum KeyPairType {
+    Ed25519,
+    Curve25519,
+}
+
+impl KeyPair {
+    pub fn new(keypair_type: KeyPairType) -> KeyPair {
+        match keypair_type {
+            KeyPairType::Ed25519 => {
+                let kp = dryoc::sign::SigningKeyPair::gen_with_defaults();
+
+                return KeyPair {
+                    keypair_type: KeyPairType::Ed25519,
+                    public_key: kp.public_key.to_vec(),
+                    secret_key: kp.secret_key.to_vec(),
+                };
+            }
+            KeyPairType::Curve25519 => {
+                let kp = dryoc::keypair::KeyPair::gen_with_defaults();
+
+                return KeyPair {
+                    keypair_type: KeyPairType::Curve25519,
+                    public_key: kp.public_key.to_vec(),
+                    secret_key: kp.secret_key.to_vec(),
+                };
+            }
+        }
+    }
+
+    pub fn decode(encoded_keypair: Vec<u8>) -> Result<KeyPair, SelfError> {
+        return match serde_cbor::from_slice(&encoded_keypair) {
+            Ok(keypair) => Ok(keypair),
+            Err(_) => Err(SelfError::KeyPairDecodeInvalidData),
+        };
+    }
+
+    pub fn encode(&self) -> Vec<u8> {
+        return serde_cbor::to_vec(self).unwrap();
+    }
+
+    pub fn keypair_type(&self) -> KeyPairType {
+        return self.keypair_type;
+    }
+
+    pub fn public(&self) -> Vec<u8> {
+        return self.public_key.clone();
+    }
+
+    pub fn sign(&self, message: &[u8]) -> Result<Vec<u8>, SelfError> {
+        if self.secret_key.len() < 1 {
+            return Err(SelfError::KeyPairSignMissingSingingKey);
+        }
+
+        if self.keypair_type != KeyPairType::Ed25519 {
+            return Err(SelfError::KeyPairSignWrongKeypairType);
+        }
+
+        return match SigningKeyPair::<PublicKey, SecretKey>::from_slices(
+            &self.public_key,
+            &self.secret_key,
+        ) {
+            Ok(kp) => match kp.sign_with_defaults(message) {
+                Ok(signed_message) => {
+                    let (sig, _) = signed_message.into_parts();
+                    return Ok(sig.to_vec());
+                }
+                Err(_) => Err(SelfError::KeyPairSignFailure),
+            },
+            Err(_) => Err(SelfError::KeyPairSignFailure),
+        };
+    }
+
+    pub fn verify(&self, message: &[u8], signature: &[u8]) -> bool {
+        let sm =
+            match SignedMessage::<Signature, Message>::from_bytes(&[signature, message].concat()) {
+                Ok(sm) => sm,
+                Err(_) => return false,
+            };
+
+        let sk = self.signing_key();
+        if sk.is_none() {
+            return false;
+        }
+
+        match sm.verify(&sk.unwrap().public_key) {
+            Ok(_) => return true,
+            Err(_) => return false,
+        }
+    }
+
+    fn signing_key(&self) -> Option<SigningKeyPair<PublicKey, SecretKey>> {
+        return match SigningKeyPair::<PublicKey, SecretKey>::from_slices(
+            &self.public_key,
+            &self.secret_key,
+        ) {
+            Ok(kp) => Some(kp),
+            Err(_) => None,
+        };
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn keypar_new() {
+        let skp = KeyPair::new(KeyPairType::Ed25519);
+        assert_eq!(skp.public().len(), 32);
+
+        let ekp = KeyPair::new(KeyPairType::Curve25519);
+        assert_eq!(ekp.public().len(), 32);
+    }
+
+    #[test]
+    fn keypair_sign_verify() {
+        let skp = KeyPair::new(KeyPairType::Ed25519);
+        assert_eq!(skp.public().len(), 32);
+
+        // sign some data
+        let message = "hello".as_bytes();
+        let signature = skp.sign(message).unwrap();
+        assert!(signature.len() == 64);
+
+        // verify the signature
+        assert!(skp.verify(message, &signature));
+
+        // verify a bad signature
+        let mut bad_signature = signature.clone();
+        bad_signature[0] = 100;
+        assert!(!skp.verify(message, &bad_signature));
+
+        // verify a bad message
+        let bad_message = "goodbye".as_bytes();
+        assert!(!skp.verify(bad_message, &signature));
+
+        // try and sign a message with a curve25519 encryption key
+        let ekp = KeyPair::new(KeyPairType::Curve25519);
+        let signature_result = ekp.sign(message);
+        assert!(signature_result.is_err());
+    }
+
+    #[test]
+    fn keypair_encode_decode() {
+        let skp = KeyPair::new(KeyPairType::Ed25519);
+        assert_eq!(skp.public().len(), 32);
+
+        // sign some data
+        let message = "hello".as_bytes();
+        let signature = skp.sign(message).unwrap();
+        assert!(signature.len() == 64);
+
+        // encode and decode the keypair
+        let encoded_skp = skp.encode();
+        let decoded_skp = KeyPair::decode(encoded_skp).unwrap();
+
+        // verify the signature
+        assert!(decoded_skp.verify(message, &signature));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,2 @@
-pub fn add(left: usize, right: usize) -> usize {
-    left + right
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
-    }
-}
+pub mod error;
+pub mod keypair;


### PR DESCRIPTION
- [x] Implements keypairs `ed25519`  for signing and `curve25519` keypairs for encryption (needed for olm)
- [x] signing and signature verification
- [x] keypair encode and decode  